### PR TITLE
Make demo compatible with Java 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,9 @@
 hs_err_pid*
 
 *.iml
+
+# Gradle
+
+build/*
+.gradle/*
+

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,22 @@
 buildscript {
   repositories {
     mavenCentral()
+    maven {
+       url "https://plugins.gradle.org/m2/"
+    }
   }
   dependencies {
     classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.21'
+    classpath "org.openjfx:javafx-plugin:0.0.10"
   }
 }
 
 apply plugin: "kotlin"
+apply plugin: "org.openjfx.javafxplugin"
+
+javafx {
+    modules = [ 'javafx.controls', 'javafx.fxml' ]
+}
 
 repositories {
   mavenCentral()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Java 11 SE removed JavaFX. As a result, it is not possible to build the SQL Injection Demo on Java 11.
This pull request:

- add and apply the [JavaFX Plugin](https://github.com/openjfx/javafx-gradle-plugin)
- upgrades Gradle to 5.6
- ignore folders `.gradle/` and `build/`

closes: #1 